### PR TITLE
Add SSH key fingerprints and info command

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,6 +8,10 @@ on:
   pull_request:
     branches: [ main ]
 
+# Set minimal permissions by default (principle of least privilege)
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 
@@ -136,7 +140,10 @@ jobs:
     needs: build
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    
+    # This job needs write permissions to create releases
+    permissions:
+      contents: write
+
     steps:
     - uses: actions/checkout@v3
       with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -538,7 +538,7 @@ checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
 name = "mnemossh"
-version = "0.1.9"
+version = "0.1.10"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -525,6 +525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
 
 [[package]]
+name = "md5"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
+
+[[package]]
 name = "memchr"
 version = "2.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -544,6 +550,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hmac",
+ "md5",
  "rand 0.9.2",
  "secrecy",
  "sha2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mnemossh"
-version = "0.1.9"
+version = "0.1.10"
 edition = "2024"
 authors = ["Ales Bykau <abkvme>"]
 description = "A library and CLI tool for generating and managing Ed25519 SSH keys using BIP-39 mnemonic phrases"
@@ -28,6 +28,7 @@ rand = "0.9.2"
 zeroize = { version = "1.8.2", features = ["zeroize_derive"] }
 hex = "0.4.3"
 time = { version = "0.3.44", features = ["local-offset"] }
+md5 = "0.7.0"
 
 # CLI
 clap = { version = "4.5.48", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ MnemoSSH is a Rust-based library and command-line utility designed to generate a
 - **Generate SSH keys from mnemonic phrases**: Create Ed25519 SSH keys deterministically from BIP-39 mnemonic phrases
 - **Create new mnemonics**: Generate cryptographically secure mnemonic phrases (12, 18, or 24 words)
 - **Restore keys**: Easily recover your SSH keys from your saved mnemonic phrase
+- **Key fingerprints**: Display MD5 and SHA256 fingerprints in OpenSSH format for all key operations
+- **Key inspection**: View detailed information about existing SSH keys, including fingerprints
 - **Compatible with OpenSSH**: Generated keys work with standard SSH tools and servers
 - **Passphrase protection**: Optionally encrypt your private keys with a passphrase
 - **Fully interactive**: Guided, interactive workflows when command-line parameters aren't provided
@@ -34,7 +36,7 @@ The binary will be available at `target/release/mnemossh`.
 
 ## Usage
 
-MnemoSSH provides four main commands: `generate`, `restore`, `verify`, and `version`. All commands support both their full name and their aliases (`gen`, `res`, `ver`, and `v` respectively).
+MnemoSSH provides five main commands: `generate`, `restore`, `verify`, `info`, and `version`. All commands support both their full name and their aliases (`gen`, `res`, `ver`, `i`, and `v` respectively).
 
 ### Generate a new SSH key with mnemonic
 
@@ -48,6 +50,19 @@ mnemossh generate
 **With all options:**
 ```bash
 mnemossh gen -o ~/.ssh/id_ed25519 -c user@example.com -l 24 -m ~/.ssh/mnemonic.txt -p mysecretpass
+```
+
+**Output includes fingerprints:**
+```
+✓ SSH keys saved successfully:
+  Private key: /Users/user/.ssh/id_ed25519
+  Public key:  /Users/user/.ssh/id_ed25519.pub
+
+🔑 Key fingerprints:
+  MD5:12:f8:7e:78:61:b4:bf:e2:de:24:15:96:4e:d4:72:53
+  SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+
+✓ Mnemonic saved to file: /Users/user/.ssh/mnemonic.txt
 ```
 
 ### Restore an SSH key from mnemonic
@@ -70,6 +85,17 @@ mnemossh restore "abandon ability able about ..."
 mnemossh res "abandon ability able about ..." -o ~/.ssh/id_ed25519 -c user@example.com -p mysecretpass
 ```
 
+**Output includes fingerprints:**
+```
+✓ SSH keys restored successfully:
+  Private key: /Users/user/.ssh/id_ed25519
+  Public key:  /Users/user/.ssh/id_ed25519.pub
+
+🔑 Key fingerprints:
+  MD5:12:f8:7e:78:61:b4:bf:e2:de:24:15:96:4e:d4:72:53
+  SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+```
+
 ### Verify key integrity
 
 The `verify` command checks that an existing SSH key matches a given mnemonic phrase. The mnemonic can be provided as a parameter or entered interactively.
@@ -88,6 +114,46 @@ mnemossh verify "abandon ability able about ..."
 **With key path specified:**
 ```bash
 mnemossh ver "abandon ability able about ..." -k ~/.ssh/id_ed25519
+```
+
+**Output includes fingerprints:**
+```
+✓ Key verification successful!
+
+🔑 Key fingerprints:
+  MD5:12:f8:7e:78:61:b4:bf:e2:de:24:15:96:4e:d4:72:53
+  SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+```
+
+### Display key information
+
+The `info` command displays detailed information about an existing SSH key, including its fingerprints.
+
+**Basic usage:**
+```bash
+mnemossh info
+# Uses default SSH location (~/.ssh/id_ed25519)
+```
+
+**With key path specified:**
+```bash
+mnemossh info -k ~/.ssh/id_ed25519
+# or using alias
+mnemossh i -k ~/.ssh/id_ed25519
+```
+
+**Example output:**
+```
+🔑 SSH Key Information
+
+Key Type:    ssh-ed25519
+Comment:     user@example.com
+
+Fingerprints:
+  MD5:     12:f8:7e:78:61:b4:bf:e2:de:24:15:96:4e:d4:72:53
+  SHA256:  nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+
+Key File:    /Users/user/.ssh/id_ed25519.pub
 ```
 
 ### Display version information
@@ -208,6 +274,16 @@ Verify that a key matches a mnemonic phrase.
     - Custom location (enter path)
   - The utility will check if this key was generated from the provided mnemonic phrase
 
+### `info` Command (alias: `i`)
+
+Display information about an existing SSH key.
+
+**Parameters:**
+
+- `-k, --key <FILE>`: The SSH key file to inspect
+  - If not specified, uses the default SSH location (`~/.ssh/id_ed25519`)
+  - Displays key type, comment, and fingerprints (MD5 and SHA256)
+
 ### `version` Command (alias: `v`)
 
 Display version information about the MnemoSSH utility.
@@ -216,7 +292,7 @@ Display version information about the MnemoSSH utility.
 
 ## Library Usage
 
-MnemoSSH can be used as a library in other Rust projects:
+MnemoSSH can be used as a library in other Rust projects. For complete examples, see the [examples](examples/) directory.
 
 ```rust
 use mnemossh::{Mnemonic, MnemonicLength, generate_keypair_from_mnemonic};
@@ -230,9 +306,25 @@ let mnemonic = Mnemonic::from_phrase("abandon ability able about ...")?;
 // Generate a key pair
 let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("user@example.com"), None)?;
 
+// Get fingerprints
+println!("MD5:     {}", keypair.md5_fingerprint());
+println!("SHA256:  {}", keypair.sha256_fingerprint());
+
 // Save the key pair
 let (private_path, public_path) = keypair.save_to_files("~/.ssh/id_ed25519")?;
 ```
+
+## Contributing
+
+We welcome contributions! Please see our [Contributing Guidelines](CONTRIBUTING.md) for details on how to get started, and our [Code of Conduct](CODE_OF_CONDUCT.md) for community guidelines.
+
+## Contact
+
+For questions, feedback, or discussions, you can reach out to the author on X: [@abkvme](https://x.com/abkvme)
+
+## Security
+
+For information about security best practices and how to report security vulnerabilities, please see our [Security Policy](SECURITY.md).
 
 ## Security Considerations
 

--- a/src/cli/commands.rs
+++ b/src/cli/commands.rs
@@ -188,9 +188,20 @@ pub fn generate_command(
     ))?;
 
     term.write_line(&format!(
-        "{} Public key saved to: {}\n",
+        "{} Public key saved to: {}",
         style("✓").green().bold(),
         style(public_path.display()).cyan()
+    ))?;
+
+    // Display key fingerprints
+    term.write_line(&format!(
+        "\n{} Key fingerprints:",
+        style("🔑").cyan().bold()
+    ))?;
+    term.write_line(&format!("  {}", style(keypair.md5_fingerprint()).dim()))?;
+    term.write_line(&format!(
+        "  {}\n",
+        style(keypair.sha256_fingerprint()).dim()
     ))?;
 
     // Save or display the mnemonic phrase

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -19,6 +19,7 @@ mod commands_update;
 
 pub use commands::generate_command;
 pub use commands::version_command;
+pub use commands_update::info_command;
 pub use commands_update::restore_command;
 pub use commands_update::verify_command;
 
@@ -138,6 +139,25 @@ pub enum Commands {
         key: Option<PathBuf>,
     },
 
+    /// Display information about an existing SSH key
+    #[clap(
+        name = "info",
+        alias = "i",
+        about = "Display information about an existing SSH key",
+        long_about = "Show detailed information about an existing SSH key, including key type, comment, fingerprints (MD5 and SHA256), and file paths."
+    )]
+    Info {
+        /// The SSH key file to display information about (defaults to ~/.ssh/id_ed25519)
+        #[clap(
+            short,
+            long,
+            value_name = "FILE",
+            help = "The SSH key file to display information about",
+            long_help = "Specify the path to the SSH key file. If not specified, defaults to ~/.ssh/id_ed25519."
+        )]
+        key: Option<PathBuf>,
+    },
+
     /// Display version information
     #[clap(
         name = "version",
@@ -191,6 +211,8 @@ pub fn run() -> Result<()> {
         Commands::Verify { mnemonic, key } => {
             commands_update::verify_command(mnemonic.as_deref(), key.clone())
         }
+
+        Commands::Info { key } => commands_update::info_command(key.clone()),
 
         Commands::Version => commands::version_command(),
     }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -2,11 +2,124 @@
  * Tests for the CLI commands
  */
 
-use mnemossh::cli::version_command;
+use mnemossh::cli::{info_command, version_command};
+use mnemossh::crypto::keys::generate_keypair_from_mnemonic;
+use mnemossh::crypto::mnemonic::{Mnemonic, MnemonicLength};
+use std::fs;
+use tempfile::tempdir;
 
 #[test]
 fn test_version_command() {
     // Test that version_command runs without error
     let result = version_command();
     assert!(result.is_ok(), "version_command should succeed");
+}
+
+#[test]
+fn test_info_command_with_existing_key() {
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("test_key");
+
+    // Create a test key
+    let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let keypair =
+        generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+    keypair.save_to_files(&key_path).unwrap();
+
+    // Test info command on the existing key
+    let result = info_command(Some(key_path.clone()));
+    assert!(
+        result.is_ok(),
+        "info_command should succeed with existing key"
+    );
+}
+
+#[test]
+fn test_info_command_with_nonexistent_key() {
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("nonexistent_key");
+
+    // Test info command on non-existent key
+    let result = info_command(Some(key_path));
+    assert!(result.is_err(), "info_command should fail with non-existent key");
+}
+
+#[test]
+fn test_info_command_with_invalid_key_format() {
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("invalid_key");
+    let public_key_path = key_path.with_extension("pub");
+
+    // Create an invalid public key file
+    fs::write(&public_key_path, "invalid key content").unwrap();
+
+    // Test info command on invalid key
+    let result = info_command(Some(key_path));
+    assert!(
+        result.is_err(),
+        "info_command should fail with invalid key format"
+    );
+}
+
+#[test]
+fn test_info_command_with_empty_key_file() {
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("empty_key");
+    let public_key_path = key_path.with_extension("pub");
+
+    // Create an empty public key file
+    fs::write(&public_key_path, "").unwrap();
+
+    // Test info command on empty key
+    let result = info_command(Some(key_path));
+    assert!(
+        result.is_err(),
+        "info_command should fail with empty key file"
+    );
+}
+
+#[test]
+fn test_restore_and_verify_commands() {
+    use mnemossh::cli::{restore_command, verify_command};
+
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("restored_key");
+
+    // Create a known mnemonic
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+
+    // Test restore command with all parameters (non-interactive)
+    let result = restore_command(Some(phrase), Some(key_path.clone()), Some("test@example.com"), Some(""));
+    assert!(result.is_ok(), "restore_command should succeed with all parameters provided");
+
+    // Test verify command with a generated key
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+    let verify_key_path = temp_dir.path().join("verify_key");
+    keypair.save_to_files(&verify_key_path).unwrap();
+
+    // Verify should succeed with matching mnemonic
+    let verify_result = verify_command(Some(phrase), Some(verify_key_path.clone()));
+    assert!(verify_result.is_ok(), "verify_command should succeed with matching mnemonic");
+
+    // Verify should fail with different mnemonic
+    let different_phrase = "legal winner thank year wave sausage worth useful legal winner thank yellow";
+    let verify_result_fail = verify_command(Some(different_phrase), Some(verify_key_path));
+    assert!(verify_result_fail.is_err(), "verify_command should fail with non-matching mnemonic");
+}
+
+#[test]
+fn test_key_pair_methods() {
+    // Test additional KeyPair methods for coverage
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+
+    // Test verifying_key method
+    let verifying_key = keypair.verifying_key();
+    assert!(!format!("{:?}", verifying_key).is_empty());
+
+    // Test that private and public keys are non-empty
+    assert!(!keypair.private_key_openssh().is_empty());
+    assert!(!keypair.public_key_openssh().is_empty());
 }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -41,7 +41,10 @@ fn test_info_command_with_nonexistent_key() {
 
     // Test info command on non-existent key
     let result = info_command(Some(key_path));
-    assert!(result.is_err(), "info_command should fail with non-existent key");
+    assert!(
+        result.is_err(),
+        "info_command should fail with non-existent key"
+    );
 }
 
 #[test]
@@ -89,23 +92,39 @@ fn test_restore_and_verify_commands() {
     let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
 
     // Test restore command with all parameters (non-interactive)
-    let result = restore_command(Some(phrase), Some(key_path.clone()), Some("test@example.com"), Some(""));
-    assert!(result.is_ok(), "restore_command should succeed with all parameters provided");
+    let result = restore_command(
+        Some(phrase),
+        Some(key_path.clone()),
+        Some("test@example.com"),
+        Some(""),
+    );
+    assert!(
+        result.is_ok(),
+        "restore_command should succeed with all parameters provided"
+    );
 
     // Test verify command with a generated key
     let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
-    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+    let keypair =
+        generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
     let verify_key_path = temp_dir.path().join("verify_key");
     keypair.save_to_files(&verify_key_path).unwrap();
 
     // Verify should succeed with matching mnemonic
     let verify_result = verify_command(Some(phrase), Some(verify_key_path.clone()));
-    assert!(verify_result.is_ok(), "verify_command should succeed with matching mnemonic");
+    assert!(
+        verify_result.is_ok(),
+        "verify_command should succeed with matching mnemonic"
+    );
 
     // Verify should fail with different mnemonic
-    let different_phrase = "legal winner thank year wave sausage worth useful legal winner thank yellow";
+    let different_phrase =
+        "legal winner thank year wave sausage worth useful legal winner thank yellow";
     let verify_result_fail = verify_command(Some(different_phrase), Some(verify_key_path));
-    assert!(verify_result_fail.is_err(), "verify_command should fail with non-matching mnemonic");
+    assert!(
+        verify_result_fail.is_err(),
+        "verify_command should fail with non-matching mnemonic"
+    );
 }
 
 #[test]
@@ -113,7 +132,8 @@ fn test_key_pair_methods() {
     // Test additional KeyPair methods for coverage
     let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
     let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
-    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+    let keypair =
+        generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
 
     // Test verifying_key method
     let verifying_key = keypair.verifying_key();

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -84,3 +84,56 @@ fn test_default_ssh_key_path() {
         );
     }
 }
+
+#[test]
+fn test_key_gen_config_default() {
+    use mnemossh::KeyGenConfig;
+
+    let config = KeyGenConfig::default();
+
+    // Verify default values
+    assert!(config.output_path.to_string_lossy().contains("id_ed25519"));
+    assert!(config.comment.is_none());
+    assert!(config.passphrase.is_none());
+    assert!(config.mnemonic_file.is_none());
+}
+
+#[test]
+fn test_key_gen_config_display() {
+    use mnemossh::{KeyGenConfig, crypto::mnemonic::MnemonicLength};
+    use std::path::PathBuf;
+
+    let config = KeyGenConfig {
+        output_path: PathBuf::from("/test/path"),
+        comment: Some("test@example.com".to_string()),
+        passphrase: Some("secret".to_string()),
+        mnemonic_length: MnemonicLength::Words24,
+        mnemonic_file: Some(PathBuf::from("/test/mnemonic.txt")),
+    };
+
+    let display = format!("{}", config);
+
+    // Should contain path and comment but not passphrase
+    assert!(display.contains("/test/path"));
+    assert!(display.contains("test@example.com"));
+    assert!(display.contains("[redacted]")); // Passphrase should be redacted
+    assert!(!display.contains("secret")); // Actual passphrase should not appear
+}
+
+#[test]
+fn test_error_types() {
+    use mnemossh::Error;
+
+    // Test various error types can be created
+    let _err1 = Error::InvalidMnemonic("test".to_string());
+    let _err2 = Error::KeyGenerationFailed("test".to_string());
+    let _err3 = Error::InvalidKeyFormat("test".to_string());
+    let _err4 = Error::VerificationFailed("test".to_string());
+    let _err5 = Error::CryptoError("test".to_string());
+    let _err6 = Error::SshKeyError("test".to_string());
+    let _err7 = Error::UserCancelled("test".to_string());
+
+    // Test error display
+    let err = Error::InvalidMnemonic("bad phrase".to_string());
+    assert!(format!("{}", err).contains("bad phrase"));
+}

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -204,3 +204,186 @@ fn test_keypair_debug_format() {
     // The public key should be included in the debug output
     assert!(debug_str.contains("public_key"));
 }
+
+/// Test MD5 fingerprint format
+#[test]
+fn test_md5_fingerprint_format() {
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+
+    let md5_fp = keypair.md5_fingerprint();
+
+    // Check format: MD5:xx:xx:xx:... (16 hex pairs separated by colons)
+    assert!(md5_fp.starts_with("MD5:"));
+    let hex_part = md5_fp.strip_prefix("MD5:").unwrap();
+    let parts: Vec<&str> = hex_part.split(':').collect();
+    assert_eq!(parts.len(), 16, "MD5 fingerprint should have 16 hex pairs");
+
+    // Each part should be a 2-character hex string
+    for part in parts {
+        assert_eq!(part.len(), 2, "Each hex pair should be 2 characters");
+        assert!(
+            part.chars().all(|c| c.is_ascii_hexdigit()),
+            "Each character should be hex digit"
+        );
+    }
+}
+
+/// Test SHA256 fingerprint format
+#[test]
+fn test_sha256_fingerprint_format() {
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+
+    let sha256_fp = keypair.sha256_fingerprint();
+
+    // Check format: SHA256:base64_string
+    assert!(sha256_fp.starts_with("SHA256:"));
+    let b64_part = sha256_fp.strip_prefix("SHA256:").unwrap();
+
+    // Base64 string should not be empty and should not have padding
+    assert!(!b64_part.is_empty());
+    assert!(!b64_part.ends_with('='), "OpenSSH format has no padding");
+}
+
+/// Test fingerprints are consistent for same key
+#[test]
+fn test_fingerprints_consistency() {
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+
+    // Generate two keypairs from the same mnemonic
+    let keypair1 = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+    let keypair2 = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+
+    // Fingerprints should be identical
+    assert_eq!(keypair1.md5_fingerprint(), keypair2.md5_fingerprint());
+    assert_eq!(
+        keypair1.sha256_fingerprint(),
+        keypair2.sha256_fingerprint()
+    );
+}
+
+/// Test fingerprints are different for different keys
+#[test]
+fn test_fingerprints_uniqueness() {
+    let mnemonic1 = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let mnemonic2 = Mnemonic::new(MnemonicLength::Words12).unwrap();
+
+    let keypair1 = generate_keypair_from_mnemonic(&mnemonic1, None, None).unwrap();
+    let keypair2 = generate_keypair_from_mnemonic(&mnemonic2, None, None).unwrap();
+
+    // Fingerprints should be different
+    assert_ne!(keypair1.md5_fingerprint(), keypair2.md5_fingerprint());
+    assert_ne!(
+        keypair1.sha256_fingerprint(),
+        keypair2.sha256_fingerprint()
+    );
+}
+
+/// Test KeyPair::from_seed with short seed
+#[test]
+fn test_keypair_from_seed_short() {
+    use mnemossh::crypto::keys::KeyPair;
+
+    // Create a seed that is too short (less than 32 bytes)
+    let short_seed = vec![0u8; 16];
+
+    let result = KeyPair::from_seed(&short_seed, None, None);
+    assert!(
+        result.is_err(),
+        "KeyPair::from_seed should fail with seed shorter than 32 bytes"
+    );
+}
+
+/// Test invalid signature verification
+#[test]
+fn test_keypair_invalid_signature_length() {
+    let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+
+    let message = b"test message";
+
+    // Test with signature that's too short
+    let short_signature = vec![0u8; 32];
+    assert!(
+        !keypair.verify(message, &short_signature),
+        "Should return false for signature with invalid length"
+    );
+
+    // Test with signature that's too long
+    let long_signature = vec![0u8; 128];
+    assert!(
+        !keypair.verify(message, &long_signature),
+        "Should return false for signature with invalid length"
+    );
+}
+
+/// Test save_to_files with nested non-existent directory
+#[test]
+fn test_keypair_save_nested_directory() {
+    let temp_dir = tempdir().unwrap();
+    let nested_path = temp_dir.path().join("level1/level2/level3/test_key");
+
+    // Parent directories don't exist
+    assert!(!nested_path.parent().unwrap().exists());
+
+    // Create a keypair and save it
+    let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+
+    // Should create all parent directories
+    let result = keypair.save_to_files(&nested_path);
+    assert!(result.is_ok(), "Should create nested directories");
+
+    let (private_path, public_path) = result.unwrap();
+    assert!(private_path.exists());
+    assert!(public_path.exists());
+
+    // Verify parent directories were created
+    assert!(nested_path.parent().unwrap().exists());
+}
+
+/// Test verify with valid-length corrupted signature
+#[test]
+fn test_keypair_verify_corrupted_signature() {
+    let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+
+    let message = b"test message";
+    let signature = keypair.sign(message);
+
+    // Create a corrupted signature with correct length (64 bytes) but wrong data
+    let mut corrupted = signature.clone();
+    // Corrupt multiple bytes to ensure it's invalid
+    for i in 0..8 {
+        corrupted[i] = corrupted[i].wrapping_add(1);
+    }
+
+    // Should return false (not panic)
+    assert!(!keypair.verify(message, &corrupted), "Should return false for corrupted signature");
+}
+
+#[cfg(unix)]
+#[test]
+fn test_keypair_unix_permissions() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let temp_dir = tempdir().unwrap();
+    let key_path = temp_dir.path().join("test_key");
+
+    // Create and save a keypair
+    let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
+    let keypair = generate_keypair_from_mnemonic(&mnemonic, None, None).unwrap();
+    let (private_path, _) = keypair.save_to_files(&key_path).unwrap();
+
+    // Check that private key has 0600 permissions on Unix
+    let metadata = fs::metadata(&private_path).unwrap();
+    let permissions = metadata.permissions();
+    let mode = permissions.mode();
+
+    // Check that permissions are 0600 (owner read/write only)
+    assert_eq!(mode & 0o777, 0o600, "Private key should have 0600 permissions");
+}

--- a/tests/keys_tests.rs
+++ b/tests/keys_tests.rs
@@ -260,10 +260,7 @@ fn test_fingerprints_consistency() {
 
     // Fingerprints should be identical
     assert_eq!(keypair1.md5_fingerprint(), keypair2.md5_fingerprint());
-    assert_eq!(
-        keypair1.sha256_fingerprint(),
-        keypair2.sha256_fingerprint()
-    );
+    assert_eq!(keypair1.sha256_fingerprint(), keypair2.sha256_fingerprint());
 }
 
 /// Test fingerprints are different for different keys
@@ -277,10 +274,7 @@ fn test_fingerprints_uniqueness() {
 
     // Fingerprints should be different
     assert_ne!(keypair1.md5_fingerprint(), keypair2.md5_fingerprint());
-    assert_ne!(
-        keypair1.sha256_fingerprint(),
-        keypair2.sha256_fingerprint()
-    );
+    assert_ne!(keypair1.sha256_fingerprint(), keypair2.sha256_fingerprint());
 }
 
 /// Test KeyPair::from_seed with short seed
@@ -332,7 +326,8 @@ fn test_keypair_save_nested_directory() {
 
     // Create a keypair and save it
     let mnemonic = Mnemonic::new(MnemonicLength::Words12).unwrap();
-    let keypair = generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
+    let keypair =
+        generate_keypair_from_mnemonic(&mnemonic, Some("test@example.com"), None).unwrap();
 
     // Should create all parent directories
     let result = keypair.save_to_files(&nested_path);
@@ -363,7 +358,10 @@ fn test_keypair_verify_corrupted_signature() {
     }
 
     // Should return false (not panic)
-    assert!(!keypair.verify(message, &corrupted), "Should return false for corrupted signature");
+    assert!(
+        !keypair.verify(message, &corrupted),
+        "Should return false for corrupted signature"
+    );
 }
 
 #[cfg(unix)]
@@ -385,5 +383,9 @@ fn test_keypair_unix_permissions() {
     let mode = permissions.mode();
 
     // Check that permissions are 0600 (owner read/write only)
-    assert_eq!(mode & 0o777, 0o600, "Private key should have 0600 permissions");
+    assert_eq!(
+        mode & 0o777,
+        0o600,
+        "Private key should have 0600 permissions"
+    );
 }

--- a/tests/mnemonic_tests.rs
+++ b/tests/mnemonic_tests.rs
@@ -114,6 +114,21 @@ fn test_mnemonic_seed_generation() {
     assert_eq!(seed, seed2);
 }
 
+/// Test mnemonic Display trait (should redact for security)
+#[test]
+fn test_mnemonic_display() {
+    let phrase = "abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about";
+    let mnemonic = Mnemonic::from_phrase(phrase).unwrap();
+
+    // Test Display trait - should be redacted for security
+    let displayed = format!("{}", mnemonic);
+    assert_eq!(displayed, "[REDACTED MNEMONIC]");
+
+    // Test Debug trait - should also be redacted
+    let debugged = format!("{:?}", mnemonic);
+    assert!(debugged.contains("[REDACTED"));
+}
+
 /// Test that multiple new mnemonics are unique
 #[test]
 fn test_mnemonic_uniqueness() {

--- a/tests/utils_tests.rs
+++ b/tests/utils_tests.rs
@@ -149,7 +149,10 @@ fn test_is_file_writable_nonexistent_parent() {
     let nonexistent_parent = temp_dir.path().join("does_not_exist").join("file.txt");
 
     // Parent doesn't exist, so should not be writable
-    assert!(!is_file_writable(&nonexistent_parent), "File in non-existent parent should not be writable");
+    assert!(
+        !is_file_writable(&nonexistent_parent),
+        "File in non-existent parent should not be writable"
+    );
 }
 
 #[cfg(unix)]
@@ -168,7 +171,10 @@ fn test_is_file_writable_readonly_parent() {
 
     let file_in_readonly = readonly_dir.join("test.txt");
     // File doesn't exist, parent is readonly
-    assert!(!is_file_writable(&file_in_readonly), "File in readonly dir should not be writable");
+    assert!(
+        !is_file_writable(&file_in_readonly),
+        "File in readonly dir should not be writable"
+    );
 
     // Restore permissions for cleanup
     perms.set_mode(0o755);


### PR DESCRIPTION
Features:
- Add MD5 and SHA256 fingerprint display to generate/restore/verify commands
- Add new 'info' command to display key information and fingerprints
- Add fingerprint calculation methods to KeyPair (md5_fingerprint, sha256_fingerprint)

Tests:
- Add comprehensive tests for fingerprint functionality
- Add tests for info command (existing keys, errors, edge cases)
- Add tests for restore and verify commands
- Add error path tests and edge case coverage
- Improve test coverage with 54 tests total

Dependencies:
- Add md5 crate for MD5 fingerprint calculation

Version: 0.1.9 -> 0.1.10

Closes #4 #7 